### PR TITLE
Include Shortcut as Submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "Libs/Shortcut"]
+	path = Libs/Shortcut
+	url = https://github.com/AlexArchive/Shortcut.git

--- a/FaceSplit.sln
+++ b/FaceSplit.sln
@@ -1,20 +1,41 @@
 ﻿
-Microsoft Visual Studio Solution File, Format Version 11.00
-# Visual C# Express 2010
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 14
+VisualStudioVersion = 14.0.23107.0
+MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FaceSplit", "FaceSplit\FaceSplit.csproj", "{0B7BB13E-4CED-4900-8EA2-5AC205967346}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Libs", "Libs", "{9523F1BA-EFB7-47D8-8E92-022CE27340E5}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Shortcut", "Libs\Shortcut\Shortcut\Shortcut.csproj", "{5DEADF0B-DC7B-430F-982E-647F7B05455D}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
 		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
 		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{0B7BB13E-4CED-4900-8EA2-5AC205967346}.Debug|Any CPU.ActiveCfg = Debug|x86
 		{0B7BB13E-4CED-4900-8EA2-5AC205967346}.Debug|x86.ActiveCfg = Debug|x86
 		{0B7BB13E-4CED-4900-8EA2-5AC205967346}.Debug|x86.Build.0 = Debug|x86
+		{0B7BB13E-4CED-4900-8EA2-5AC205967346}.Release|Any CPU.ActiveCfg = Release|x86
 		{0B7BB13E-4CED-4900-8EA2-5AC205967346}.Release|x86.ActiveCfg = Release|x86
 		{0B7BB13E-4CED-4900-8EA2-5AC205967346}.Release|x86.Build.0 = Release|x86
+		{5DEADF0B-DC7B-430F-982E-647F7B05455D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5DEADF0B-DC7B-430F-982E-647F7B05455D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5DEADF0B-DC7B-430F-982E-647F7B05455D}.Debug|x86.ActiveCfg = Debug|x86
+		{5DEADF0B-DC7B-430F-982E-647F7B05455D}.Debug|x86.Build.0 = Debug|x86
+		{5DEADF0B-DC7B-430F-982E-647F7B05455D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5DEADF0B-DC7B-430F-982E-647F7B05455D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5DEADF0B-DC7B-430F-982E-647F7B05455D}.Release|x86.ActiveCfg = Release|x86
+		{5DEADF0B-DC7B-430F-982E-647F7B05455D}.Release|x86.Build.0 = Release|x86
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{5DEADF0B-DC7B-430F-982E-647F7B05455D} = {9523F1BA-EFB7-47D8-8E92-022CE27340E5}
 	EndGlobalSection
 EndGlobal

--- a/FaceSplit/FaceSplit.csproj
+++ b/FaceSplit/FaceSplit.csproj
@@ -74,9 +74,6 @@
     <ApplicationIcon>Resources\hotkeysOn.ico</ApplicationIcon>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Shortcut">
-      <HintPath>.\Shortcut.dll</HintPath>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />
@@ -194,6 +191,12 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="Resources\noicon.png" />
+  </ItemGroup>
+  <ItemGroup>
+	<ProjectReference Include="..\Libs\Shortcut\Shortcut\Shortcut.csproj">
+      <Project>{5deadf0b-dc7b-430f-982e-647f7b05455d}</Project>
+      <Name>Shortcut</Name>
+    </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 


### PR DESCRIPTION
The Shortcut Submodule should be included as a Submodule so that cloning
the repository automatically clones the Shortcut Library too.

This change turns the solution into a Visual Studio 2015 solution though,
as I don't have 2010 anymore.
